### PR TITLE
Fix conflicts with previous declaration with the same Objective-C sel…

### DIFF
--- a/Calculator/ViewController.swift
+++ b/Calculator/ViewController.swift
@@ -36,16 +36,16 @@ class ViewController: UIViewController
             enter()
         }
         switch operation {
-            case "×": performOperation { $0 * $1 }
-            case "÷": performOperation { $1 / $0 }
-            case "+": performOperation { $0 + $1 }
-            case "−": performOperation { $1 - $0 }
-            case "√": performOperation { sqrt($0) }
+            case "×": performBinaryOperation { $0 * $1 }
+            case "÷": performBinaryOperation { $1 / $0 }
+            case "+": performBinaryOperation { $0 + $1 }
+            case "−": performBinaryOperation { $1 - $0 }
+            case "√": performUnaryOperation { sqrt($0) }
             default: break
         }
     }
     
-    func performOperation(operation: (Double, Double) -> Double)
+    func performBinaryOperation(operation: (Double, Double) -> Double)
     {
         if operandStack.count >= 2 {
             displayValue = operation(operandStack.removeLast(), operandStack.removeLast())
@@ -53,7 +53,7 @@ class ViewController: UIViewController
         }
     }
 
-    func performOperation(operation: Double -> Double)
+    func performUnaryOperation(operation: Double -> Double)
     {
         if operandStack.count >= 1 {
             displayValue = operation(operandStack.removeLast())


### PR DESCRIPTION
Fixed: Compiler error: Method with Objective-C selector conflicts with previous declaration with the same Objective-C selector.
This is because ViewController inherited UIViewController which is a NSObject. That is, ViewController is also a NSObject, so it's under Objective-C selector. :)
